### PR TITLE
Added overflow-wrap in chat scss

### DIFF
--- a/src/app/modules/game/components/chat/chat.component.scss
+++ b/src/app/modules/game/components/chat/chat.component.scss
@@ -22,6 +22,7 @@
     color: white;
     max-width: 8.5rem;
     font-family: 'Heebo', sans-serif;
+    overflow-wrap: break-word;
   }
 
   .current-user-message {


### PR DESCRIPTION
Image of word wrap in game:

![screen shot 2019-02-04 at 6 27 45 pm](https://user-images.githubusercontent.com/33385024/52246220-9de39580-28aa-11e9-9977-adc6bc4ec2c9.png)

Image of change, line 25 in chat.component.scss:

![screen shot 2019-02-04 at 6 27 25 pm](https://user-images.githubusercontent.com/33385024/52246224-a045ef80-28aa-11e9-9341-1e5bf2b41827.png)
