### PR TITLE
player can only update their online status

### DIFF
--- a/database.rules
+++ b/database.rules
@@ -1,0 +1,14 @@
+{
+  "rules": {
+    "playersOnline": {
+      ".read": true,
+      ".write": false
+    },
+    "status": {
+      "$uid": {
+     		".read": "auth.uid == $uid",
+    		".write": "auth.uid == $uid"
+      }
+    }
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -3,6 +3,9 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
+  "database": {
+    "rules": "database.rules"
+  },
   "hosting": {
     "public": "dist",
     "ignore": [


### PR DESCRIPTION
Adds actual rules to realtime database.

Player can only update their own status. Players can only read the counter for playersOnline. Only cloud functions can write
